### PR TITLE
Edit input name for auto doc generation

### DIFF
--- a/scripts/docs_policy_bundles.py
+++ b/scripts/docs_policy_bundles.py
@@ -114,7 +114,7 @@ def generate_asciidoc(data):
     return "\n".join(asciidoc_lines)
 
 def main():
-    input_filename = './bundle/bundle_metadata.json'
+    input_filename = './policy/main/main/data/data.json'
     output_filename = './docs/modules/policies/pages/index.adoc'
 
     try:


### PR DESCRIPTION
Fixed the mistake in the input file definition of the script to auto generate the policy docs